### PR TITLE
Update 2020-10-07-setup-specflow-nunit-vscode.md

### DIFF
--- a/_posts/2020/10/2020-10-07-setup-specflow-nunit-vscode.md
+++ b/_posts/2020/10/2020-10-07-setup-specflow-nunit-vscode.md
@@ -61,7 +61,6 @@ namespace SpecFlowDemo.Steps
         {
             num1 = number1;
             num2 = number2;
-            _scenarioContext.Pending();
         }
 
         [Then("the result should be (.*)")]


### PR DESCRIPTION
Remove "_scenarioContext.Pending();" as this is causing the test to skip.